### PR TITLE
[FEAT] handong_feed_client 사용하여 태그 사용시 LLM에 실데이터 전달

### DIFF
--- a/app/api/v1/endpoints/tag_labeling_router.py
+++ b/app/api/v1/endpoints/tag_labeling_router.py
@@ -1,12 +1,26 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Query
 
-from app.core.config import EnvVariables
 from app.services.tag_labeling_service import TagLabelingService
 from app.schemas.tag_labeling_dto import MessageTagLabelingRespDto
 
 tag_labeling_router = APIRouter()
 
 @tag_labeling_router.get("", response_model=MessageTagLabelingRespDto)
-def assign_tags():
+def assign_tags(
+        start_date: str = Query(..., description="조회 시작 날짜 (yyyy-mm-dd)"),
+        end_date: str = Query(..., description="조회 종료 날짜 (yyyy-mm-dd)"),
+        is_filter_new: bool = Query(False, description="신규 메시지 필터링 여부 (true 또는 false)"),
+        limit: int = Query(100, description="조회할 최대 메시지 수")
+):
+    """
+    주어진 날짜 범위와 필터, 제한 정보를 기반으로 각 메시지에 적합한 태그 코드를 할당합니다.
+
+    - start_date, end_date: yyyy-mm-dd 형식의 문자열 (예: "2025-01-01")
+    - is_filter_new: 신규 메시지 필터링 여부 (true/false)
+    - limit: 조회할 메시지 최대 개수
+
+    Returns:
+        MessageTagLabelingRespDto: 각 메시지에 할당된 태그 정보를 포함하는 DTO.
+    """
     service = TagLabelingService()
-    return service.assign_tags_to_messages_iterative(EnvVariables.SAMPLE_MESSAGES, EnvVariables.SAMPLE_TAGS)
+    return service.assign_tags_to_messages_iterative(start_date, end_date, is_filter_new, limit)

--- a/app/schemas/external/feed_dto.py
+++ b/app/schemas/external/feed_dto.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, validator, field_validator
+from pydantic import BaseModel, field_validator
 from typing import Optional, List
 
 

--- a/app/schemas/external/subject_tag_dto.py
+++ b/app/schemas/external/subject_tag_dto.py
@@ -1,5 +1,5 @@
-from datetime import date, datetime
-from typing import Optional, List
+from datetime import datetime
+from typing import Optional
 from pydantic import BaseModel
 
 class SubjectTagDto:

--- a/app/schemas/external/tag_dto.py
+++ b/app/schemas/external/tag_dto.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from pydantic import BaseModel
-from typing import Optional
+from typing import Optional, List
+
 
 class TagDto:
     class ReadResDto(BaseModel):
@@ -12,3 +13,8 @@ class TagDto:
         priorityWeight: float
         createdAt: datetime
         updatedAt: datetime
+
+    @staticmethod
+    def extract_tag_codes(tags: List["TagDto.ReadResDto"]) -> List[str]:
+        """주어진 TagDto.ReadResDto 리스트에서 각 태그의 'code' 필드만 추출하여 문자열 배열로 반환"""
+        return [tag.code for tag in tags]

--- a/app/schemas/tag_labeling_dto.py
+++ b/app/schemas/tag_labeling_dto.py
@@ -1,10 +1,13 @@
 from pydantic import BaseModel
 from typing import List
 
+from app.schemas.external.subject_tag_dto import SubjectTagDto
+
+
 class MessageTagAssignment(BaseModel):
     subject_id: str
     tag_codes: List[str]
 
 class MessageTagLabelingRespDto(BaseModel):
-    assignments: List[MessageTagAssignment]
+    assign_resp_dtos_list: List[List[SubjectTagDto.AssignRespDto]]
     

--- a/app/services/llm_service.py
+++ b/app/services/llm_service.py
@@ -8,7 +8,6 @@ from google import genai
 from google.genai import types
 
 from app.core.config import EnvVariables
-from app.schemas.external.tag_dto import TagDto
 from app.schemas.tag_labeling_dto import MessageTagAssignment
 
 logger = logging.getLogger(__name__)

--- a/app/services/tag_labeling_service.py
+++ b/app/services/tag_labeling_service.py
@@ -1,6 +1,12 @@
 import logging
-from app.schemas.tag_labeling_dto import MessageTagAssignment, MessageTagLabelingRespDto
+
+from app.clients.handong_feed_app_client import HandongFeedAppClient
+from app.schemas.external.feed_dto import FeedDto
+from app.schemas.external.subject_tag_dto import SubjectTagDto
+from app.schemas.external.tag_dto import TagDto
+from app.schemas.tag_labeling_dto import MessageTagLabelingRespDto
 from app.services.llm_service import LLMService
+from app.util.date_utils import convert_start_date_to_unix, convert_end_date_to_unix, convert_unix_to_date_str
 from app.util.pii_cleaner import mask_all_ppi
 from app.util.text_cleaner import TextCleaner
 
@@ -10,8 +16,9 @@ class TagLabelingService:
     def __init__(self):
         self.cleaner = TextCleaner()
         self.llm_service = LLMService()
+        self.handong_feed_app_client = HandongFeedAppClient()
 
-    def assign_tags_to_messages_iterative(self, messages, tags) -> MessageTagLabelingRespDto:
+    def assign_tags_to_messages_iterative(self, start_date, end_date, is_filter_new, limit) -> MessageTagLabelingRespDto:
         """
         주어진 메시지 리스트와 태그 목록을 기반으로 각 메시지에 적합한 태그 코드를 할당합니다.
 
@@ -26,41 +33,66 @@ class TagLabelingService:
              - LLM 응답이 유효하면, 해당 메시지에 대한 할당 결과(MessageTagAssignment)를 수집합니다.
           4. 모든 메시지에 대한 할당 결과를 MessageTagLabelingRespDto에 담아 반환합니다.
 
-        Args:
             messages (list): 각 메시지는 딕셔너리 형태로, 최소한 'subject_id'와 'message' 키를 포함해야 합니다.
             tags (list): 할당 가능한 태그 목록. 각 태그는 딕셔너리 형태(예: {"code": "...", "label": "...", "llm_desc": "..."})로 제공됩니다.
 
         Returns:
             MessageTagLabelingRespDto: 각 메시지의 subject_id와 할당된 태그 코드 배열을 포함하는 DTO.
     """
+        # 날짜 문자열을 Unix timestamp로 변환
+        start_ts = convert_start_date_to_unix(start_date)
+        end_ts = convert_end_date_to_unix(end_date)
 
-        if not messages:
-            logger.warning("Empty messages list provided")
-            return MessageTagLabelingRespDto(assignments=[])
+        tag_codes = TagDto.extract_tag_codes(self.handong_feed_app_client.get_all_tags())
 
-        if not tags:
-            logger.warning("Empty tags list provided")
-            return MessageTagLabelingRespDto(assignments=[])
+        feeds = self.handong_feed_app_client.get_feeds(
+            FeedDto.ReadReqDto(
+                start = start_ts,
+                end = end_ts,
+                isFilterNew = is_filter_new,
+                limit = limit
+            )
+        )
 
-        assignments = []
+        # 해당 조건에 부합하는 피드가 없다면, status 204 반환
+        if not feeds:
+            logger.warning("Empty feed list provided")
+            from fastapi import HTTPException
+            raise HTTPException(status_code=204, detail="해당 조건에 부합하는 피드가 없습니다.")
 
-        for msg in messages:
-            subject_id = msg.get("subject_id")
+        if not tag_codes:
+            logger.warning("Empty tag code list provided")
+            return MessageTagLabelingRespDto(assign_resp_dtos_list=[])
+
+        assign_resp_dtos_list = []
+
+        for feed in feeds:
+            subject_id = feed.subjectId
+            for_date = convert_unix_to_date_str(feed.sentAt)
 
             if not subject_id:
                 logger.warning("Message without subject_id found, skipping")
                 continue
 
-            raw_text = msg.get("message", "")
+            raw_text = feed.message
 
             masked_text = mask_all_ppi(raw_text)
 
             cleaned_message = self.cleaner.clean(masked_text)
 
-            assignment = self.llm_service.assign_tag_to_message(subject_id, cleaned_message, tags)
+            assignment = self.llm_service.assign_tag_to_message(str(subject_id), cleaned_message, tag_codes)
             if assignment:
-                assignments.append(assignment)
+                assign_req_dtos = []
+                for tag_code in assignment.tag_codes:
+                    assign_req_dto = SubjectTagDto.AssignReqDto(
+                        tagCode=tag_code,
+                        forDate=for_date,
+                    )
+                    assign_req_dtos.append(assign_req_dto)
+
+                assign_resp_dtos = self.handong_feed_app_client.assign_tags_batch(str(subject_id), assign_req_dtos)
+                assign_resp_dtos_list.append(assign_resp_dtos)
             else:
                 logger.debug(f"No valid assignment returned for subject_id={subject_id}")
 
-        return MessageTagLabelingRespDto(assignments=assignments)
+        return MessageTagLabelingRespDto(assign_resp_dtos_list= assign_resp_dtos_list)

--- a/app/util/date_utils.py
+++ b/app/util/date_utils.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timezone, timedelta, time
 from zoneinfo import ZoneInfo
 
 
@@ -10,3 +10,20 @@ def convert_to_kst_datetime(timestamp: float) -> datetime:
     if timestamp is None:
         return None
     return datetime.fromtimestamp(timestamp, tz=timezone.utc) + timedelta(hours=9)
+
+def convert_start_date_to_unix(date_str: str) -> int:
+    """yyyy-mm-dd 문자열을 해당 날짜의 시작(00:00:00)의 Unix 타임스탬프로 변환"""
+    dt = datetime.strptime(date_str, "%Y-%m-%d")
+    dt_start = datetime.combine(dt.date(), time.min)
+    return int(dt_start.timestamp())
+
+def convert_end_date_to_unix(date_str: str) -> int:
+    """yyyy-mm-dd 문자열을 해당 날짜의 끝(23:59:59.999999)의 Unix 타임스탬프로 변환"""
+    dt = datetime.strptime(date_str, "%Y-%m-%d")
+    dt_end = datetime.combine(dt.date(), time.max)
+    return int(dt_end.timestamp())
+
+def convert_unix_to_date_str(ts: int) -> str:
+    """Unix 타임스탬프를 "yyyy-mm-dd" 형식의 문자열로 변환"""
+    dt = datetime.fromtimestamp(ts)
+    return dt.strftime("%Y-%m-%d")

--- a/bruno/tag labeling.bru
+++ b/bruno/tag labeling.bru
@@ -5,7 +5,14 @@ meta {
 }
 
 get {
-  url: http://0.0.0.0:9000/api/v1/tag-labeling
+  url: http://0.0.0.0:9000/api/v1/tag-labeling?start_date=2025-04-14&end_date=2025-04-14&is_filter_new=1&limit=100
   body: none
   auth: inherit
+}
+
+params:query {
+  start_date: 2025-04-14
+  end_date: 2025-04-14
+  is_filter_new: 1
+  limit: 100
 }


### PR DESCRIPTION
## 주요 변경사항

1. **Unix 타임스탬프 유틸 추가 (`add unix_timestamp - datetime convert util`)**  
   - `convert_start_date_to_unix`, `convert_end_date_to_unix`, `convert_unix_to_date_str` 등의 함수를 추가하여 날짜 문자열과 Unix 타임스탬프 간 변환을 편리하게 함.

2. **TagDto에 `extract_tag_codes` 메서드 추가 (`add extract_tag_codes method to TagDto`)**  
   - 외부 API로부터 수신한 태그 목록(`ReadResDto`)에서 code 필드만 추출하여 문자열 리스트를 얻을 수 있도록 개선.

3. **`assign_resp_dtos_list` 타입 변경 (`modify type of assign_resp_dtos_list to List[List[SubjectTagDto]]`)**  
   - 다중 태그 배정 시, 배정 결과를 중첩 리스트(List[List[...]]) 형태로 처리하도록 구조 변경.

4. **LLMService에서 태그 직렬화 로직 개선 (`convert tags to dict for proper JSON serialization`)**  
   - 태그가 Pydantic 모델일 경우 JSON 직렬화가 실패하는 문제를 해결하기 위해, `.dict()`로 변환 후 `json.dumps`를 수행하도록 수정.

5. **HandongFeedAppClient 연동하여 실데이터 기반 태그 라벨링 (`use handong_feed_app_client for feed retrieval and tag assignment`)**  
   - 외부 API(태그 조회, 피드 조회)로부터 실제 데이터를 받아와, 개인정보 마스킹 → 텍스트 전처리 → LLM 기반 태그 할당 → 태그 배정(batch) 과정을 수행.

6. **쿼리 파라미터 기반으로 `/api/v1/tag-labeling` 엔드포인트 개선 (`update assign_tags endpoint to use query parameters`)**  
   - `start_date`, `end_date`, `is_filter_new`, `limit` 값을 쿼리 파라미터로 받아, 더미 데이터를 사용하지 않고 실제 데이터를 활용하도록 변경.

7. **테스트 코드 업데이트 (`test: update /api/v1/tag-labeling endpoint`)**  
   - 변경된 엔드포인트 로직에 맞춰 테스트를 정비하여, 쿼리 파라미터 및 실데이터 연동 과정을 확인.

## 결론

이 PR을 통해 **태그 라벨링** 로직이 더미 데이터가 아닌 외부 API에서 가져온 **실제 피드 및 태그 정보**를 바탕으로 동작하도록 개선되었습니다.  
Unix 타임스탬프 변환 유틸 추가, Pydantic 모델 직렬화 이슈 해결 등으로 코드 가독성과 유지보수성이 향상되었고, 외부 API 연동(HandongFeedAppClient)으로 실제 운영 환경에서 태그 라벨링 과정을 매끄럽게 수행할 수 있게 되었습니다.

## 관련 이슈
#2 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 태그 할당 API에서 조회 시작일, 종료일, 신규 메시지 필터, 최대 메시지 수를 쿼리 파라미터로 지정하여 메시지 필터링 및 제한이 가능해졌습니다.
	- 태그 DTO 리스트에서 태그 코드만 추출하는 유틸리티 메서드가 추가되었습니다.
	- 날짜 문자열과 유닉스 타임스탬프 간 변환 유틸리티 함수가 추가되었습니다.

- **기능 개선**
	- 태그 할당 서비스가 외부 시스템에서 메시지와 태그를 동적으로 조회 및 처리하도록 개선되었습니다.
	- API 문서에 각 파라미터 설명이 추가되어 사용성이 향상되었습니다.
	- 태그 할당 응답 구조가 변경되어 보다 상세한 배치 결과를 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->