### PR TITLE
[FEAT] CRON 스크립트 구현 및 외부 API (GetLatestForDate) 를 클라이언트에 추가

### DIFF
--- a/app/clients/handong_feed_app_client.py
+++ b/app/clients/handong_feed_app_client.py
@@ -76,7 +76,7 @@ class HandongFeedAppClient(BaseAPIClient):
 
     def assign_tags_batch(self, subject_id: str, assign_reqs: List[SubjectTagDto.AssignReqDto]) -> List[SubjectTagDto.AssignRespDto]:
         """
-        POST /api/external/subject/:subjectId/tag-assign-batch를 호출하여 여러 태그 배정 요청을 보냅니다.
+        POST /api/external/subject-tag/:subjectId/tag-assign-batch를 호출하여 여러 태그 배정 요청을 보냅니다.
 
         요청 예시:
         [
@@ -104,7 +104,7 @@ class HandongFeedAppClient(BaseAPIClient):
         Raises:
             Exception: API 호출 실패 또는 저장 실패 시 예외 발생
         """
-        url = f"{self.feed_base_api_url}/subject/{subject_id}/tag-assign-batch"
+        url = f"{self.feed_base_api_url}/subject-tag/{subject_id}/tag-assign-batch"
         payload = [assignment.model_dump() for assignment in assign_reqs]
         try:
             response = self.post(url, json=payload)
@@ -123,7 +123,7 @@ class HandongFeedAppClient(BaseAPIClient):
 
     def assign_tag(self, subject_id: str, assign_req: SubjectTagDto.AssignReqDto) -> SubjectTagDto.AssignRespDto:
         """
-        POST /api/external/subject/:subjectId/tag-assign를 호출하여 단일 태그 배정 요청을 보냅니다.
+        POST /api/external/subject-tag/:subjectId/tag-assign를 호출하여 단일 태그 배정 요청을 보냅니다.
 
         요청 예시:
         {
@@ -145,7 +145,7 @@ class HandongFeedAppClient(BaseAPIClient):
         Raises:
             Exception: API 호출 실패 또는 저장 실패 시 예외 발생
         """
-        url = f"{self.feed_base_api_url}/subject/{subject_id}/tag-assign"
+        url = f"{self.feed_base_api_url}/subject-tag/{subject_id}/tag-assign"
         payload = assign_req.model_dump()
         try:
             response = self.post(url, json=payload)

--- a/app/clients/handong_feed_app_client.py
+++ b/app/clients/handong_feed_app_client.py
@@ -174,6 +174,12 @@ class HandongFeedAppClient(BaseAPIClient):
         try:
             response = self.get(url)
             response.raise_for_status()
+
+            # 204 No Content 응답 처리
+            if response.status_code == 204:
+                logger.info("No latest for_date found (204 No Content)")
+                return SubjectTagDto.GetLatestForDateResDto(latestForDate=None)
+
             result_json = response.json()
             logger.info(f"Successfully get latest for_date: {result_json.get('latestForDate')}")
             return SubjectTagDto.GetLatestForDateResDto(**result_json)

--- a/app/clients/handong_feed_app_client.py
+++ b/app/clients/handong_feed_app_client.py
@@ -158,3 +158,25 @@ class HandongFeedAppClient(BaseAPIClient):
         except Exception as e:
             logger.error(f"Failed to assign tag for subject_id {subject_id}: {e}")
             raise Exception(f"Failed to assign tag for subject_id {subject_id}: {e}") from e
+
+
+    def get_latest_for_date(self) -> SubjectTagDto.GetLatestForDateResDto:
+        """
+        GET /api/external/subject-tag/latest-for-date 를 호출하여 최신 for_date 를 받습니다.
+
+        Returns:
+            ReadLatestForDateResDto: 최신 for_date 응답 DTO
+
+        Raises:
+            Exception: API 호출 실패 시 예외 발생
+        """
+        url = f"{self.feed_base_api_url}/subject-tag/latest-for-date"
+        try:
+            response = self.get(url)
+            response.raise_for_status()
+            result_json = response.json()
+            logger.info(f"Successfully get latest for_date: {result_json.get('latestForDate')}")
+            return SubjectTagDto.GetLatestForDateResDto(**result_json)
+        except Exception as e:
+            logger.error(f"Failed to get latest for_date: {e}")
+            raise Exception(f"Failed to get latest for_date: {e}") from e

--- a/app/schemas/external/subject_tag_dto.py
+++ b/app/schemas/external/subject_tag_dto.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, date
 from typing import Optional
 from pydantic import BaseModel
 
@@ -15,3 +15,6 @@ class SubjectTagDto:
         confidentValue: float
         forDate: Optional[str] = None
         createdAt: datetime
+
+    class GetLatestForDateResDto(BaseModel):
+        latestForDate: Optional[date]

--- a/app/scripts/tag_assignment_cron_job.py
+++ b/app/scripts/tag_assignment_cron_job.py
@@ -1,0 +1,47 @@
+from datetime import date, timedelta
+from fastapi import HTTPException
+
+from app.services.tag_labeling_service import TagLabelingService
+from app.core.database import SessionLocal
+
+def run():
+    db = SessionLocal()
+    service = TagLabelingService(db)
+
+    try:
+        yesterday = (date.fromisoformat("2025-01-21") - timedelta(days=1)).isoformat()
+        print(f"[CRON] Assigning tags to new feeds for {yesterday}")
+        try:
+            resp = service.process_feeds_with_date(
+                start_date=yesterday,
+                end_date=yesterday,
+                is_filter_new=1,
+                limit=100
+            )
+            print(
+                f"[CRON] Number of new feeds added yesterday that were successfully assigned: {len(resp.assign_resp_dtos_list)}")
+        except HTTPException as e:
+            if e.status_code == 204:
+                print(f"[CRON] No new feeds to process for {yesterday}.")
+            else:
+                raise e
+
+
+        print(f"\n[CRON] Retrying failed tag assignments...")
+        try:
+            resp =  service.process_failed_feeds()
+            print(f"[CRON] Number of failed feeds that were successfully assigned by retry: {len(resp.assign_resp_dtos_list)}")
+        except HTTPException as e:
+            if e.status_code == 204:
+                print(f"[CRON] No failed feeds to process.")
+            else:
+                raise e
+
+    except Exception as e:
+        print(f"[CRON ERROR] {e}")
+
+    finally:
+        db.close()
+
+if __name__ == "__main__":
+    run()

--- a/app/scripts/tag_assignment_cron_job.py
+++ b/app/scripts/tag_assignment_cron_job.py
@@ -27,18 +27,19 @@ def run():
                 raise e
 
 
-        print(f"\n[CRON] Retrying failed tag assignments...")
+        print("\n[CRON] Retrying failed tag assignments...")
         try:
             resp =  service.process_failed_feeds()
             print(f"[CRON] Number of failed feeds that were successfully assigned by retry: {len(resp.assign_resp_dtos_list)}")
         except HTTPException as e:
             if e.status_code == 204:
-                print(f"[CRON] No failed feeds to process.")
+                print("[CRON] No failed feeds to process.")
             else:
                 raise e
 
     except Exception as e:
-        print(f"[CRON ERROR] {e}")
+        import logging
+        logging.error(f"[CRON] Error during tag assignment: {e}", exc_info=True)
 
     finally:
         db.close()

--- a/app/scripts/tag_assignment_cron_job.py
+++ b/app/scripts/tag_assignment_cron_job.py
@@ -9,7 +9,7 @@ def run():
     service = TagLabelingService(db)
 
     try:
-        yesterday = (date.fromisoformat("2025-01-21") - timedelta(days=1)).isoformat()
+        yesterday = (date.today() - timedelta(days=1)).isoformat()
         print(f"[CRON] Assigning tags to new feeds for {yesterday}")
         try:
             resp = service.process_feeds_with_date(

--- a/app/scripts/tag_assignment_cron_job.py
+++ b/app/scripts/tag_assignment_cron_job.py
@@ -1,19 +1,23 @@
 from datetime import date, timedelta
 from fastapi import HTTPException
 
+from app.clients.handong_feed_app_client import HandongFeedAppClient
 from app.services.tag_labeling_service import TagLabelingService
 from app.core.database import SessionLocal
 
 def run():
     db = SessionLocal()
     service = TagLabelingService(db)
+    client = HandongFeedAppClient()
 
     try:
         yesterday = (date.today() - timedelta(days=1)).isoformat()
-        print(f"[CRON] Assigning tags to new feeds for {yesterday}")
+        latest_for_date = str(client.get_latest_for_date().latestForDate + timedelta(days=1))
+
+        print(f"[CRON] Assigning tags to new feeds for {latest_for_date} ~ {yesterday}")
         try:
             resp = service.process_feeds_with_date(
-                start_date=yesterday,
+                start_date=latest_for_date,
                 end_date=yesterday,
                 is_filter_new=1,
                 limit=100


### PR DESCRIPTION
## 주요 변경사항

- CRON 스크립트 구현:
  1. 신규 피드 태깅: 전날 추가된 신규 피드에 대해 자동으로 태그를 할당
  2. 실패한 피드 재시도: 이전에 태그 할당에 실패했던 피드에 대해 할당 재시도 
  (204 No Content 처리: 신규 피드가 없는 경우(204 응답)에도 에러 없이 정상 종료되도록 처리)

- 외부 API (GetLatestForDate) 를 클라이언트에 추가

## 관련이슈
#84 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **신규 기능**
  - 피드에 태그를 자동으로 할당하는 일일 자동화 스크립트가 추가되었습니다.
  - 태그 할당 관련 API 경로가 업데이트되어 안정성이 향상되었습니다.
  - 최신 처리 날짜를 조회하는 기능이 추가되어 태그 할당 대상 피드를 효율적으로 관리합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->