### PR TITLE
[SCRIPT,CLIENT/FEAT] 주제 태그 할당 성공 시 is_tag_assigned 업데이트 기능 추가

### DIFF
--- a/app/clients/base_api_client.py
+++ b/app/clients/base_api_client.py
@@ -33,3 +33,17 @@ class BaseAPIClient:
         except requests.exceptions.RequestException as e:
             logging.error(f"POST 요청 실패: {url}, 오류: {str(e)}")
             raise
+
+    def patch(self, url, **kwargs):
+        try:
+            response = self.session.patch(url, **kwargs)
+            response.raise_for_status()  # 4xx, 5xx 응답에 대해 예외 발생
+            return response
+        except requests.exceptions.HTTPError as e:
+            # HTTP 에러가 발생한 경우 (ex: 404, 500)
+            logging.error(f"PATCH 요청 실패 (HTTP 오류) - URL: {url}, 상태 코드: {e.response.status_code}, 오류: {e}")
+            raise
+        except requests.exceptions.RequestException as e:
+            # 연결 실패, Timeout 등 기타 모든 Request 예외
+            logging.error(f"PATCH 요청 실패 (네트워크 오류) - URL: {url}, 오류: {e}")
+            raise

--- a/app/clients/base_api_client.py
+++ b/app/clients/base_api_client.py
@@ -19,19 +19,25 @@ class BaseAPIClient:
     def get(self, url, **kwargs):
         try:
             response = self.session.get(url, **kwargs)
-            response.raise_for_status()  # 4xx, 5xx 응답에 대해 예외 발생
+            response.raise_for_status()
             return response
+        except requests.exceptions.HTTPError as e:
+            logging.error(f"GET 요청 실패 (HTTP 오류) - URL: {url}, 상태 코드: {e.response.status_code}, 오류: {e}")
+            raise
         except requests.exceptions.RequestException as e:
-            logging.error(f"GET 요청 실패: {url}, 오류: {str(e)}")
+            logging.error(f"GET 요청 실패 (네트워크 오류) - URL: {url}, 오류: {e}")
             raise
 
     def post(self, url, **kwargs):
         try:
             response = self.session.post(url, **kwargs)
-            response.raise_for_status()  # 4xx, 5xx 응답에 대해 예외 발생
+            response.raise_for_status()
             return response
+        except requests.exceptions.HTTPError as e:
+            logging.error(f"POST 요청 실패 (HTTP 오류) - URL: {url}, 상태 코드: {e.response.status_code}, 오류: {e}")
+            raise
         except requests.exceptions.RequestException as e:
-            logging.error(f"POST 요청 실패: {url}, 오류: {str(e)}")
+            logging.error(f"POST 요청 실패 (네트워크 오류) - URL: {url}, 오류: {e}")
             raise
 
     def patch(self, url, **kwargs):

--- a/app/clients/base_api_client.py
+++ b/app/clients/base_api_client.py
@@ -16,40 +16,34 @@ class BaseAPIClient:
         # 타임아웃 설정 (connect=5초, read=30초)
         self.session.timeout = (5, 30)
 
-    def get(self, url, **kwargs):
+    def _send_request(self, method, url, **kwargs):
+        """
+        HTTP 요청을 보내고 공통적으로 예외를 처리하는 private 메서드
+
+        Args:
+            method (str): HTTP 메서드 ('GET', 'POST', 'PATCH' 등)
+            url (str): 요청할 URL
+            kwargs: 추가 요청 옵션
+
+        Returns:
+            requests.Response: 요청 결과 응답
+        """
         try:
-            response = self.session.get(url, **kwargs)
+            response = self.session.request(method, url, **kwargs)
             response.raise_for_status()
             return response
         except requests.exceptions.HTTPError as e:
-            logging.error(f"GET 요청 실패 (HTTP 오류) - URL: {url}, 상태 코드: {e.response.status_code}, 오류: {e}")
+            logging.error(f"{method} 요청 실패 (HTTP 오류) - URL: {url}, 상태 코드: {e.response.status_code}, 오류: {e}")
             raise
         except requests.exceptions.RequestException as e:
-            logging.error(f"GET 요청 실패 (네트워크 오류) - URL: {url}, 오류: {e}")
+            logging.error(f"{method} 요청 실패 (네트워크 오류) - URL: {url}, 오류: {e}")
             raise
+
+    def get(self, url, **kwargs):
+        return self._send_request('GET', url, **kwargs)
 
     def post(self, url, **kwargs):
-        try:
-            response = self.session.post(url, **kwargs)
-            response.raise_for_status()
-            return response
-        except requests.exceptions.HTTPError as e:
-            logging.error(f"POST 요청 실패 (HTTP 오류) - URL: {url}, 상태 코드: {e.response.status_code}, 오류: {e}")
-            raise
-        except requests.exceptions.RequestException as e:
-            logging.error(f"POST 요청 실패 (네트워크 오류) - URL: {url}, 오류: {e}")
-            raise
+        return self._send_request('POST', url, **kwargs)
 
     def patch(self, url, **kwargs):
-        try:
-            response = self.session.patch(url, **kwargs)
-            response.raise_for_status()  # 4xx, 5xx 응답에 대해 예외 발생
-            return response
-        except requests.exceptions.HTTPError as e:
-            # HTTP 에러가 발생한 경우 (ex: 404, 500)
-            logging.error(f"PATCH 요청 실패 (HTTP 오류) - URL: {url}, 상태 코드: {e.response.status_code}, 오류: {e}")
-            raise
-        except requests.exceptions.RequestException as e:
-            # 연결 실패, Timeout 등 기타 모든 Request 예외
-            logging.error(f"PATCH 요청 실패 (네트워크 오류) - URL: {url}, 오류: {e}")
-            raise
+        return self._send_request('PATCH', url, **kwargs)

--- a/app/clients/handong_feed_app_client.py
+++ b/app/clients/handong_feed_app_client.py
@@ -186,3 +186,40 @@ class HandongFeedAppClient(BaseAPIClient):
         except Exception as e:
             logger.error(f"Failed to get latest for_date: {e}")
             raise Exception(f"Failed to get latest for_date: {e}") from e
+
+    def update_is_tag_assigned_true(self, subject_id: int):
+        """
+        PATCH /api/external/subject/{subjectId}/tag-assigned를 호출하여
+        주제 ID를 기반으로 태그 할당 완료 상태로 갱신합니다.
+
+        Args:
+            subject_id (int): 업데이트할 주제 ID
+
+        Raises:
+            Exception: API 호출 실패 또는 지정된 주제를 찾을 수 없는 경우
+        """
+        url = f"{self.feed_base_api_url}/subject/{subject_id}/tag-assigned"
+
+        import requests
+        try:
+            response = self.patch(url)
+
+            # 예상한 204 No Content 응답 처리
+            if response.status_code == 204:
+                return
+
+            # 예상 외의 정상 응답 (ex: 200, 201)이 오면 의심
+            raise Exception(f"Unexpected success response: {response.status_code}")
+
+        except requests.exceptions.HTTPError as e:
+            status_code = e.response.status_code
+
+            if status_code == 404:
+                raise Exception(f"Subject not found with ID: {subject_id}")
+            elif status_code == 403:
+                raise Exception(f"Access denied when updating subject with ID: {subject_id}")
+            else:
+                raise Exception(f"HTTP error occurred while updating subject: {e}")
+
+        except requests.exceptions.RequestException as e:
+            raise Exception(f"Failed to update is_tag_assigned for subject: {subject_id}. Error: {e}")

--- a/app/clients/handong_feed_app_client.py
+++ b/app/clients/handong_feed_app_client.py
@@ -1,4 +1,5 @@
 import logging
+import requests
 from typing import List
 
 from app.clients.base_api_client import BaseAPIClient
@@ -200,7 +201,6 @@ class HandongFeedAppClient(BaseAPIClient):
         """
         url = f"{self.feed_base_api_url}/subject/{subject_id}/tag-assigned"
 
-        import requests
         try:
             response = self.patch(url)
 

--- a/app/clients/handong_feed_app_client.py
+++ b/app/clients/handong_feed_app_client.py
@@ -215,11 +215,11 @@ class HandongFeedAppClient(BaseAPIClient):
             status_code = e.response.status_code
 
             if status_code == 404:
-                raise Exception(f"Subject not found with ID: {subject_id}")
+                raise Exception(f"Subject not found with ID: {subject_id}") from e
             elif status_code == 403:
-                raise Exception(f"Access denied when updating subject with ID: {subject_id}")
+                raise Exception(f"Access denied when updating subject with ID: {subject_id}") from e
             else:
-                raise Exception(f"HTTP error occurred while updating subject: {e}")
+                raise Exception(f"HTTP error occurred while updating subject: {e}") from e
 
         except requests.exceptions.RequestException as e:
-            raise Exception(f"Failed to update is_tag_assigned for subject: {subject_id}. Error: {e}")
+            raise Exception(f"Failed to update is_tag_assigned for subject: {subject_id}. Error: {e}") from e


### PR DESCRIPTION
## 주요 변경사항
-	태그 할당(Tag Assignment)이 성공한 후, 해당 주제(Subject)의 is_tag_assigned 필드를 true로 업데이트하는 로직을 추가했습니다.
-	client.update_is_tag_assigned_true(subjectId) 호출을 통해 외부 API를 호출하여 상태를 반영합니다.
-	이를 위해 헬퍼 메서드 update_subject_tag_assignment(client, assign_resp_dtos_list)를 새롭게 작성했습니다.
-	크론 스크립트에서 신규/재시도 작업(process_feeds_with_date, process_failed_feeds) 모두 완료 후 업데이트가 진행됩니다.
-	HandongFeedAppClient.update_is_tag_assigned_true 메서드에 예외 처리를 개선했습니다.  
	- requests 라이브러리 import를 메서드 내부가 아닌 모듈 최상단으로 이동했습니다.
	- 예외 발생 시 from e 문법을 적용하여 예외 체이닝을 명확히 했습니다.
	- GET, POST 메서드에도 패치와 동일한 레벨의 상세한 에러 로깅을 추가했습니다.
- 	`BaseAPIClient` 클래스에서 get, post, patch 메서드에 중복되던 HTTP 요청 및 예외 처리 로직을 하나의 private 메서드 `_send_request`로 통합했습니다.
	-	각 HTTP 메서드(get, post, patch)는 `_send_request`를 호출하여 코드 중복 없이 간결하게 구현되었습니다.

## 추가 설명
-	태그가 성공적으로 할당된 경우에만 is_tag_assigned를 true로 변경합니다.
-	Subject Id가 없는 경우에는 예외를 발생시키지 않고, 정상적인 흐름만 처리합니다.
-	헬퍼 메서드를 통해 중복 코드를 제거하고, 로직의 재사용성과 가독성을 높였습니다.
- API 호출 시 204 No Content 정상 응답을 기대하고, 404/403 등 에러 응답에 대해 명확하게 예외를 발생시킵니다.

## 관련 작업
-	HandongFeedApp 내 /api/external/subject/{subjectId}/tag-assigned PATCH API 호출
-	update_is_tag_assigned_true 호출 시 204 No Content 정상 응답을 기대

## 관련이슈
https://github.com/handong-app/handong-feed-app/issues/84
resolves https://github.com/handong-app/handong-feed-app/issues/142

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **신규 기능**
    - 과목의 태그 할당 상태를 PATCH 요청을 통해 업데이트하는 기능이 추가되었습니다.
- **버그 수정**
    - 예외 발생 시 로깅 후 예외가 정상적으로 전파되도록 수정되었습니다.
- **리팩터링**
    - 태그 할당 상태 업데이트 로직이 별도의 헬퍼 함수로 분리되어 코드의 명확성과 재사용성이 향상되었습니다.
    - HTTP 요청 처리 방식이 통합되어 일관된 예외 처리와 코드 간소화가 이루어졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->