### PR TITLE
[Refactor] inline tag assignment state update into tagging logic

### DIFF
--- a/app/scripts/tag_assignment_cron_job.py
+++ b/app/scripts/tag_assignment_cron_job.py
@@ -6,20 +6,6 @@ from app.services.tag_labeling_service import TagLabelingService
 from app.core.database import SessionLocal
 
 
-def update_subject_tag_assignment(client, assign_resp_dtos_list):
-    """
-    주제 태그 할당 완료 처리를 위한 헬퍼 메서드.
-
-    Args:
-        client: HandongFeedAppClient 인스턴스
-        assign_resp_dtos_list: 태그 할당 응답 DTO 리스트
-    """
-    for dto in assign_resp_dtos_list:
-        if dto and hasattr(dto[0], 'tbSubjectId') and dto[0].tbSubjectId:
-            print(f"[CRON] Updating subject tag assignment for tbSubjectId={dto[0].tbSubjectId}")
-            client.update_is_tag_assigned_true(dto[0].tbSubjectId)
-
-
 def run():
     db = SessionLocal()
     service = TagLabelingService(db)
@@ -40,7 +26,6 @@ def run():
             print(
                 f"[CRON] Number of new feeds added yesterday that were successfully assigned: {len(resp.assign_resp_dtos_list)}")
 
-            update_subject_tag_assignment(client, resp.assign_resp_dtos_list)
 
         except HTTPException as e:
             if e.status_code == 204:
@@ -54,7 +39,6 @@ def run():
             resp =  service.process_failed_feeds()
             print(f"[CRON] Number of failed feeds that were successfully assigned by retry: {len(resp.assign_resp_dtos_list)}")
 
-            update_subject_tag_assignment(client, resp.assign_resp_dtos_list)
 
         except HTTPException as e:
             if e.status_code == 204:

--- a/app/services/tag_labeling_service.py
+++ b/app/services/tag_labeling_service.py
@@ -148,4 +148,19 @@ class TagLabelingService:
                     )
                 continue
 
+        self.update_subject_tag_assignment(assign_resp_dtos_list)
+
         return MessageTagLabelingRespDto(assign_resp_dtos_list= assign_resp_dtos_list)
+
+    def update_subject_tag_assignment(self, assign_resp_dtos_list):
+        """
+        주제 태그 할당 완료 처리를 위한 헬퍼 메서드.
+
+        Args:
+            client: HandongFeedAppClient 인스턴스
+            assign_resp_dtos_list: 태그 할당 응답 DTO 리스트
+        """
+        for dto in assign_resp_dtos_list:
+            if dto and hasattr(dto[0], 'tbSubjectId') and dto[0].tbSubjectId:
+                print(f"[CRON] Updating subject tag assignment for tbSubjectId={dto[0].tbSubjectId}")
+                self.handong_feed_app_client.update_is_tag_assigned_true(dto[0].tbSubjectId)

--- a/app/services/tag_labeling_service.py
+++ b/app/services/tag_labeling_service.py
@@ -157,10 +157,9 @@ class TagLabelingService:
         주제 태그 할당 완료 처리를 위한 헬퍼 메서드.
 
         Args:
-            client: HandongFeedAppClient 인스턴스
             assign_resp_dtos_list: 태그 할당 응답 DTO 리스트
         """
         for dto in assign_resp_dtos_list:
             if dto and hasattr(dto[0], 'tbSubjectId') and dto[0].tbSubjectId:
-                print(f"[CRON] Updating subject tag assignment for tbSubjectId={dto[0].tbSubjectId}")
+                logger.info(f"Updating subject tag assignment for tbSubjectId={dto[0].tbSubjectId}")
                 self.handong_feed_app_client.update_is_tag_assigned_true(dto[0].tbSubjectId)


### PR DESCRIPTION
## 주요 변경사항
- update_subject_tag_assignment() 메서드를 별도 함수에서 assign_tags_to_messages_iterative() 내부 로직으로 이동시켜 구조를 단순화했습니다.
- 태그 할당 성공 이후 subject의 is_tag_assigned 상태를 true로 업데이트하는 로직이 메시지 처리 흐름 내에서 바로 수행되도록 리팩터링했습니다.

## 리팩터링 배경
- 태그 할당 성공 이후의 상태 갱신은 메시지 처리 흐름과 밀접하게 연결된 작업이므로, 하나의 연산 단위로 포함시키는 것이 더 명확합니다.
- 외부 헬퍼 함수로 관리하던 로직을 내부화함으로써 추적성과 응집력을 높였습니다.
- 반복 사용 가능성이 낮은 로직을 별도 함수로 유지하는 것보다, 해당 context 내에서 처리하는 것이 가독성과 유지보수에 더 유리하다고 판단했습니다.

## 기대 효과
- 관련 로직의 위치가 명확해져 가독성과 흐름 이해도가 향상됨
- 불필요한 외부 호출 제거로 구조 간결화
- 추후 메시지 처리 로직 확장 시 유연한 관리 가능

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **기능 개선**
  - 태그 할당 후 subject 태그 상태 업데이트 로직이 개선되었습니다. 태그 할당 결과에 따라 subject의 태그 할당 상태가 보다 정확하게 반영됩니다.  
- **버그 수정**
  - 태그 할당 처리 후 subject 상태가 일부 반영되지 않던 문제가 해결되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->