### PR TITLE
[BE/FEAT] LLMService Singleton 적용 및 요청 속도 제한 기능 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,9 @@ GEMINI_API_KEY=
 # GEMINI_API_URL: Gemini API의 엔드포인트 URL을 설정합니다.
 GEMINI_API_URL=
 
+# LLM_API_REQUESTS_PER_MINUTE: LLM API의 분당 요청 횟수 제한을 설정합니다.
+LLM_API_REQUESTS_PER_MINUTE=
+
 # SAMPLE_TAGS: 테스트용 임시 태그 데이터를 JSON 문자열 형식으로 설정합니다.
 # 예: [{"code": "club", "label": "동아리 활동", "llm_desc": "설명"}]
 SAMPLE_TAGS=

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -27,6 +27,8 @@ class EnvVariables:
     GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
     GEMINI_API_URL = os.getenv("GEMINI_API_URL")
 
+    LLM_API_REQUESTS_PER_MINUTE = int(os.getenv("LLM_API_REQUESTS_PER_MINUTE", "15"))
+
     SAMPLE_TAGS = json.loads(os.getenv("SAMPLE_TAGS", "[]"))
     SAMPLE_MESSAGES = json.loads(os.getenv("SAMPLE_MESSAGES", "[]"))
 

--- a/app/scripts/tag_assignment_cron_job.py
+++ b/app/scripts/tag_assignment_cron_job.py
@@ -53,7 +53,6 @@ def run():
                 raise e
 
     except Exception as e:
-        import logging
         logging.error(f"[CRON] Error during tag assignment: {e}", exc_info=True)
 
     finally:

--- a/app/scripts/tag_assignment_cron_job.py
+++ b/app/scripts/tag_assignment_cron_job.py
@@ -1,9 +1,15 @@
+import logging
 from datetime import date, timedelta
 from fastapi import HTTPException
 
 from app.clients.handong_feed_app_client import HandongFeedAppClient
 from app.services.tag_labeling_service import TagLabelingService
 from app.core.database import SessionLocal
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s - %(message)s",
+)
 
 
 def run():

--- a/app/services/llm_service.py
+++ b/app/services/llm_service.py
@@ -33,7 +33,8 @@ class LLMService:
                 if attempt == max_attempts:
                     raise Exception(
                         f"assign_tag_to_message 실패: {subject_id}에 대해 {max_attempts}번 시도했으나 실패했습니다. ({e})") from e
-
+                return None
+        return None
 
     def request_tag_assignment(self, message, tags) -> str:
         """

--- a/app/services/llm_service.py
+++ b/app/services/llm_service.py
@@ -30,7 +30,7 @@ class LLMService:
         if self.request_count >= EnvVariables.LLM_API_REQUESTS_PER_MINUTE:
             # 분당 요청 초과했으면 대기
             wait_seconds = 60 - (now - self.request_window_start).seconds
-            logger.info(f"[LLMService] 15회 요청 완료. {wait_seconds}초 대기합니다...")
+            logger.info(f"[LLMService] {EnvVariables.LLM_API_REQUESTS_PER_MINUTE}회 요청 완료. {wait_seconds}초 대기합니다...")
             time.sleep(wait_seconds)
             # 초기화
             self.request_count = 0

--- a/app/services/tag_labeling_service.py
+++ b/app/services/tag_labeling_service.py
@@ -9,9 +9,9 @@ from app.schemas.external.subject_tag_dto import SubjectTagDto
 from app.schemas.external.tag_dto import TagDto
 from app.schemas.tag_assign_fail_log_dto import TagAssignFailLogDto
 from app.schemas.tag_labeling_dto import MessageTagLabelingRespDto, AssignTagsToMessageServDto
-from app.services.llm_service import LLMService
+from app.services.llm_service import llm_service_singleton
 from app.services.tag_fail_log_service import TagFailLogService
-from app.util.date_utils import convert_start_date_to_unix, convert_end_date_to_unix, convert_unix_to_date_str
+from app.util.date_utils import convert_start_date_to_unix, convert_end_date_to_unix
 from app.util.pii_cleaner import mask_all_ppi
 from app.util.text_cleaner import TextCleaner
 
@@ -21,7 +21,7 @@ class TagLabelingService:
     def __init__(self, db: Session):
         self.db = db
         self.cleaner = TextCleaner()
-        self.llm_service = LLMService()
+        self.llm_service = llm_service_singleton
         self.handong_feed_app_client = HandongFeedAppClient()
         self.tag_fail_log_service = TagFailLogService(db)
 


### PR DESCRIPTION
## 주요 변경사항
- LLMService를 싱글톤 인스턴스로 변경
  - llm_service_singleton 객체를 생성하여, 전역에서 공유되도록 처리
  - TagLabelingService에서는 개별 인스턴스를 생성하지 않고 해당 싱글톤을 주입받도록 변경
- 요청 속도 제한 로직 추가
  - enforce_rate_limit() 메서드를 통해 분당 요청 수(RPM)를 제어
  - LLM_API_REQUESTS_PER_MINUTE 환경변수를 통해 제한값 설정 가능
  - 초과 시 내부적으로 sleep() 호출하여 대기 후 요청 재개
- 로깅 개선
  - 요청 제한 도달 시 "요청 완료, 대기" 메시지를 로그로 출력
  - 싱글톤 사용을 통해 전체 태깅 과정의 호출 수를 일관되게 추적 가능
 
##  환경변수
```env
LLM_API_REQUESTS_PER_MINUTE=15
```

## 작동 시나리오
- date 기준 신규 피드 최대 100개에 대해 태깅을 진행 시, 15회 단위로 요청이 제한되고 정상적으로 처리됨
- 실패한 피드 재처리 시에도 동일한 제한 로직이 적용됨
  - 싱글톤 llm_service 사용으로, date 기준 신규피드 처리 시 사용되던 API 요청보낸 횟수 변수와 타이머 그대로 가져와서 사용
- 로그에 대기 메시지가 정상 출력됨

##  관련 이슈
- resolves #23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - LLM API 요청 횟수 제한(분당 요청 수 제한) 기능이 추가되었습니다. 환경 변수로 제한값을 설정할 수 있습니다.

- **버그 수정**
    - 태그 할당 서비스에서 LLM 서비스 인스턴스가 싱글톤으로 통합되어 일관된 요청 제한이 적용됩니다.

- **기타**
    - 태그 할당 크론잡 스크립트에 로깅 설정이 추가되어 로그 메시지 형식과 레벨이 개선되었습니다.
    - 환경 변수 예시 파일에 LLM API 요청 제한 관련 항목이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->