### PR TITLE
[fix] retry loop exits early on first exception during tag assignment

### DIFF
--- a/app/services/llm_service.py
+++ b/app/services/llm_service.py
@@ -58,7 +58,6 @@ class LLMService:
                 if attempt == max_attempts:
                     raise Exception(
                         f"assign_tag_to_message 실패: {subject_id}에 대해 {max_attempts}번 시도했으나 실패했습니다. ({e})") from e
-                return None
         return None
 
     def request_tag_assignment(self, message, tags) -> str:


### PR DESCRIPTION
## 📌 관련 이슈
Closes #28

___ 

## ✨ 작업 내용
- 예외 발생 시에도 3회 재시도 로직이 정상 동작하도록 수정

___ 

## 🔎 세부 설명
- 첫 번째 예외에서 `return None`이 발생해 루프가 조기에 종료되는 문제를 제거하여 재시도 루프가 완전히 수행되도록 수정

___ 

## 📁 변경된 파일/폴더
- `services/llm_service.py`

___ 

## ➕ 기타
- 빈 배열인 경우 처리는, 'other' 태그를 주는 방법도 있지만, DB에 'other' 태그를 추가하게 되면 LLM한테 other 라는 선택지가 제공되게 됩니다.
- 이 경우 추가적인 처리가 필요하므로, 다음 작업 때 고려해 볼 필요가 있습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - 예외 처리 블록 내 불필요한 반환문을 제거하여 코드 가독성을 개선했습니다.  


<!-- end of auto-generated comment: release notes by coderabbit.ai -->