### PR TITLE
[BUG] fix: add missing FEED_API_KEY to GitHub Actions env

### DIFF
--- a/.github/workflows/tag-assignment.yml
+++ b/.github/workflows/tag-assignment.yml
@@ -19,6 +19,7 @@ jobs:
       DB_CLASSNAME: ${{ secrets.DB_CLASSNAME }}
       DB_PORT: ${{ secrets.DB_PORT }}
       FEED_API_BASE_URL: ${{ secrets.FEED_API_BASE_URL }}
+      FEED_API_KEY: ${{ secrets.FEED_API_KEY }}
       LLM_PROVIDER: ${{ secrets.LLM_PROVIDER }}
       HUGGING_FACE_TOKEN: ${{ secrets.HUGGING_FACE_TOKEN }}
       OLLAMA_MODEL: ${{ secrets.OLLAMA_MODEL }}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 닫을 이슈 번호를 명시해주세요 
Closes #이슈번호 -->

---

## ✨ 작업 내용
- GitHub Actions 환경변수 설정에서 누락된 `FEED_API_KEY` 항목 추가

---

## 🔎 세부 설명
- `EnvVariables.FEED_API_KEY`를 사용하는 코드가 있음에도 GitHub Actions workflow env 설정에 키가 누락되어 실행 중 오류가 발생했습니다.
- `.github/workflows/tag_assignment.yml` 파일 내에 해당 키를 명시적으로 추가하여 런타임 오류를 방지했습니다.

---

## 📁 변경된 파일/폴더
- `.github/workflows/tag_assignment.yml`

---

## ➕ 기타
- 별도

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - GitHub Actions 워크플로우에 `FEED_API_KEY` 환경 변수를 추가하여 실행 중 사용할 수 있도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->