### PR TITLE
Feature/38 feed tagging unassigned now

### DIFF
--- a/app/schemas/external/feed_dto.py
+++ b/app/schemas/external/feed_dto.py
@@ -10,6 +10,7 @@ class FeedDto:
         start: Optional[int] = None
         end: Optional[int] = None
         isFilterNew: int = 1
+        onlyUnassignedFeeds: int = 1
         limit: Optional[int] = None
 
     class ReadRespDto(BaseModel):

--- a/app/scripts/tag_assignment_action.py
+++ b/app/scripts/tag_assignment_action.py
@@ -31,7 +31,7 @@ def run():
                 limit=100
             )
             logging.info(
-                f"[ACTION] Number of new feeds added yesterday that were successfully assigned: {len(resp.assign_resp_dtos_list)}")
+                f"[ACTION] Number of new feeds that were successfully assigned: {len(resp.assign_resp_dtos_list)}")
 
 
         except HTTPException as e:

--- a/app/scripts/tag_assignment_action.py
+++ b/app/scripts/tag_assignment_action.py
@@ -18,15 +18,16 @@ def run():
     client = HandongFeedAppClient()
 
     try:
-        yesterday = (date.today() - timedelta(days=1)).isoformat()
-        latest_for_date = str(client.get_latest_for_date().latestForDate + timedelta(days=1))
+        today = (date.today()).isoformat()
+        latest_for_date = str(client.get_latest_for_date().latestForDate)
 
-        logging.info(f"[ACTION] Assigning tags to new feeds for {latest_for_date} ~ {yesterday}")
+        logging.info(f"[ACTION] Assigning tags to new feeds for {latest_for_date} ~ {today}")
         try:
             resp = service.process_feeds_with_date(
                 start_date=latest_for_date,
-                end_date=yesterday,
+                end_date=today,
                 is_filter_new=1,
+                onlyUnassignedFeeds=1,
                 limit=100
             )
             logging.info(
@@ -35,7 +36,7 @@ def run():
 
         except HTTPException as e:
             if e.status_code == 204:
-                logging.info(f"[ACTION] No new feeds to process for {yesterday}.")
+                logging.info(f"[ACTION] No new feeds to process for {today}.")
             else:
                 raise e
 

--- a/app/services/tag_labeling_service.py
+++ b/app/services/tag_labeling_service.py
@@ -25,7 +25,7 @@ class TagLabelingService:
         self.handong_feed_app_client = HandongFeedAppClient()
         self.tag_fail_log_service = TagFailLogService(db)
 
-    def process_feeds_with_date(self, start_date, end_date, is_filter_new, limit) -> MessageTagLabelingRespDto:
+    def process_feeds_with_date(self, start_date, end_date, is_filter_new, onlyUnassignedFeeds, limit) -> MessageTagLabelingRespDto:
         """
         start_date 와 end_date 사이에 생성됝 피드를 assign 시도합니다.
 
@@ -43,6 +43,7 @@ class TagLabelingService:
                     start=start_ts,
                     end=end_ts,
                     isFilterNew=is_filter_new,
+                    onlyUnassignedFeeds=onlyUnassignedFeeds,
                     limit=limit
                 )
             )

--- a/app/services/tag_labeling_service.py
+++ b/app/services/tag_labeling_service.py
@@ -29,6 +29,13 @@ class TagLabelingService:
         """
         start_date 와 end_date 사이에 생성됝 피드를 assign 시도합니다.
 
+        Args:
+            start_date: 조회 시작 날짜
+            end_date: 조회 종료 날짜
+            is_filter_new: 새로운 피드만 필터링할지 여부
+            onlyUnassignedFeeds: 태그가 할당되지 않은 피드만 필터링할지 여부
+            limit: 조회할 피드 수 제한
+
         Returns:
             MessageTagLabelingRespDto: 각 메시지의 subject_id와 할당된 태그 코드 배열을 포함하는 DTO.
         """


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 닫을 이슈 번호를 명시해주세요 
Closes #이슈번호 -->
Closes #38 
___ 

## ✨ 작업 내용
<!-- 이번 PR에서 어떤 작업을 했는지 간략히 설명해주세요
e.g.,
- 로그인 API 추가
- JWT 토큰 발급 로직 구현
- 예외 케이스 처리 -->
- 태깅 처리 범위를 어제로 한정하지 않고 당일까지(today) 포함하도록 수정
- onlyUnassignedFeeds=1 조건을 추가하여 태그가 아직 할당되지 않은 피드만 처리하도록 개선
___ 

## 🔎 세부 설명
<!-- 구현 내용에 관해 구체적으로 적어주세요
e.g.,
- 헬퍼 메서드를 통해 중복 코드를 제거하고, 로직의 재사용성과 가독성을 높였습니다.
- API 호출 시 204 No Content 정상 응답을 기대하고, 404/403 등 에러 응답에 대해 명확하게 예외를 발생시킵니다.-->
- 기존에는 yesterday = date.today() - timedelta(days=1) 기준으로 어제 날짜 까지만 진행했으나, 벨리데이터 가동 후 바로 태깅 처리하기 위해 오늘 날짜 기준으로 변경
- 기존에는 latest_for_date 에서 하루를 더한 날짜로 start를 지정했지만, 누락을 방지하기 위해 latest_for_date 를 start로 사용
- 중복해서 태깅 처리가 되지 않도록 onlyUnassignedFeeds == 1 조건을 적용
___ 

## 📁 변경된 파일/폴더
<!-- 변경된 주요 파일 경로나 구조가 있다면 정리해주세요
e.g.,
- `api/v1/endpoints/tag_labeling_router.py`
- `services/llm_service.py`-->
- `app/scripts/run_tag_assignment_runner.py`
- `app/services/tag_labeling_service.py`
___ 

## ➕ 기타
<!-- 추가적으로 작성할 내용이 있다면 적어주세요 --> 
- `.env`에 `onlyUnassignedFeeds`등 파라미터들을 추가해서 Actions에서 쉽게 관리할 수 있는 구조로 개선 고려 가능


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 피드 조회 시 '미할당 피드만' 필터가 추가되어, 미할당된 피드만 선택적으로 조회할 수 있습니다.

- **버그 수정**
  - 피드 처리 기준 날짜가 '어제'에서 '오늘'로 변경되어, 더 정확한 날짜 기준으로 피드가 처리됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->